### PR TITLE
Version 4.12.0 (visionOS 1.7.0)

### DIFF
--- a/Sudoku.xcodeproj/project.pbxproj
+++ b/Sudoku.xcodeproj/project.pbxproj
@@ -333,7 +333,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 29;
+				CURRENT_PROJECT_VERSION = 30;
 				DEVELOPMENT_ASSET_PATHS = "\"Sudoku/Preview Content\"";
 				DEVELOPMENT_TEAM = 49BZEB79BF;
 				ENABLE_PREVIEWS = YES;
@@ -344,7 +344,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 4.11.0;
+				MARKETING_VERSION = 4.12.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.rckim.Sudoku;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator xros xrsimulator";
@@ -372,7 +372,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 29;
+				CURRENT_PROJECT_VERSION = 30;
 				DEVELOPMENT_ASSET_PATHS = "\"Sudoku/Preview Content\"";
 				DEVELOPMENT_TEAM = 49BZEB79BF;
 				ENABLE_PREVIEWS = YES;
@@ -383,7 +383,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 4.11.0;
+				MARKETING_VERSION = 4.12.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.rckim.Sudoku;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator xros xrsimulator";

--- a/Sudoku.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Sudoku.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -7,7 +7,7 @@
       "location" : "https://github.com/lzell/aiproxyswift",
       "state" : {
         "branch" : "main",
-        "revision" : "05f5d838b1d2f90ee584a243ce9cb5acb4afdcbc"
+        "revision" : "2dac6b8d720d10b0cfa9c97d95f896f82f80f938"
       }
     }
   ],

--- a/Sudoku/API.swift
+++ b/Sudoku/API.swift
@@ -31,9 +31,9 @@ struct API {
         return urlRequest
     }
 
-    static func getHint(grid: [CoordinateValue], difficulty: Difficulty.Level) async throws -> String? {
+    static func getHint(grid: [CoordinateValue], difficulty: Difficulty.Level) async throws -> Hint? {
         if let singleHint = SudokuSolver.findSingles(grid).first {
-            return singleHint.description
+            return singleHint
         }
         
         let openAIService = AIProxy.openAIService(
@@ -66,7 +66,8 @@ struct API {
                 messages: [.system(content: .text(content))]
             )
             let response = try await openAIService.chatCompletionRequest(body: requestBody)
-            return response.choices.first?.message.content
+            let hint = Hint(coordinate: nil, hintType: .open, overrideDescription: response.choices.first?.message.content)
+            return hint
         } catch AIProxyError.unsuccessfulRequest(statusCode: let statusCode, responseBody: let responseBody) {
             print("Received \(statusCode) status code with response body: \(responseBody)")
             if statusCode == 429 {

--- a/Sudoku/API.swift
+++ b/Sudoku/API.swift
@@ -32,6 +32,10 @@ struct API {
     }
 
     static func getHint(grid: [CoordinateValue], difficulty: Difficulty.Level) async throws -> String? {
+        if let singleHint = SudokuSolver.findSingles(grid).first {
+            return singleHint.description
+        }
+        
         let openAIService = AIProxy.openAIService(
             partialKey: "v2|c7d0ff39|qrIzn_OLLetLdcWN",
             serviceURL: "https://api.aiproxy.pro/c160196f/657d65d2"
@@ -39,29 +43,28 @@ struct API {
 
         let stringGrid = GridFactory.stringGridFor(grid: grid)
         let difficultyString = difficulty.rawValue.lowercased()
+        
         let content = """
             You are a Sudoku assistant. The following is a Sudoku puzzle of \(difficultyString) difficulty.
-            Empty cells are marked as 0. The grid is represented as 9 arrays, each representing a 3x3 block 
+            Empty cells are marked as 0. The grid is represented as 9 arrays, each representing a 3x3 square
             from left to right, top to bottom:
 
             \(stringGrid)
 
-            Provide one specific, accurate hint that:
-            1. For easy: Focus on single candidates or obvious patterns
-            2. For medium: Look for hidden pairs or pointing pairs
-            3. For hard: Suggest advanced techniques like X-Wings or XY-Wings
-            4. Always verify numbers mentioned in your hint are valid in their stated positions. Double-check 
-               that suggested numbers to place in empty cells do not already have a digit there in the input 
-               grid. A hint is valid if it does not violate standard Sudoku rules.
-            5. Use at most 2 sentences
-            6. Never give away direct solutions
-            7. Use terminology that is appropriate when helping a human and not a computer. When referring
-               to rows and columns, make it clear which ones (e.g., fourth row from the top). Refer to 0 as
-               an empty cell.
+            Provide one specific, accurate hint following the following rules:
+            1. For easy difficulty: Look for obvious patterns or scanning techniques
+            2. For medium difficulty: Suggest looking for hidden pairs or pointing pairs
+            3. For hard difficulty: Guide towards advanced techniques like X-Wings or XY-Wings
+            4. Always verify your hint is valid and doesn't violate Sudoku rules
+            5. Use at most 2 sentences and never give direct solutions
+            6. Use natural language when referring to positions (e.g., 'third row from top')
         """
         
         do {
-            let requestBody = OpenAIChatCompletionRequestBody(model: "gpt-4o-mini", messages: [.system(content: .text(content))])
+            let requestBody = OpenAIChatCompletionRequestBody(
+                model: "gpt-4o-mini",
+                messages: [.system(content: .text(content))]
+            )
             let response = try await openAIService.chatCompletionRequest(body: requestBody)
             return response.choices.first?.message.content
         } catch AIProxyError.unsuccessfulRequest(statusCode: let statusCode, responseBody: let responseBody) {

--- a/Sudoku/Game/HintButton.swift
+++ b/Sudoku/Game/HintButton.swift
@@ -37,7 +37,7 @@ struct HintButton: View {
     /// Note: used for iOS and iPadOS
     @State private var hintState: LoadingState = .idle
     
-    private static var hintCache: [String: String] = [:]
+    private static var hintCache: [String: Hint] = [:]
     static func clearCache() {
         hintCache.removeAll()
     }
@@ -97,11 +97,11 @@ struct HintButton: View {
     }
     
     private func getHint() async {
-        func updateOnSuccess(_ hint: String) {
-            hintState = .loaded(message: hint)
+        func updateOnSuccess(_ hint: Hint) {
+            hintState = .loaded(message: hint.description)
 
             if isVision {
-                alertItem = .hintSuccess(hint: hint)
+                alertItem = .hintSuccess(hint: hint.description)
                 alertIsPresented = true
             }
         }
@@ -109,6 +109,7 @@ struct HintButton: View {
             showingHintSheet = !isVision
             hintState = .loading
             
+            // check cache first
             let cacheKey = grid.map { coordinate in String(coordinate.v) }.joined()
             
             if let cachedHint = Self.hintCache[cacheKey] {
@@ -116,8 +117,10 @@ struct HintButton: View {
                 return
             }
             
+            // fetch hint from API and cache
             if let hint = try await API.getHint(grid: grid, difficulty: difficulty) {
                 Self.hintCache[cacheKey] = hint
+                print(Self.hintCache)
                 updateOnSuccess(hint)
             } else {
                 hintState = .error(nil)

--- a/Sudoku/Game/HintButton.swift
+++ b/Sudoku/Game/HintButton.swift
@@ -105,32 +105,33 @@ struct HintButton: View {
         }
     }
     
+    private func updateOnError(_ error: API.APIError?) {
+        hintState = .error(error)
+
+        if isVision {
+            alertItem = .hintError
+            alertIsPresented = true
+        }
+    }
+    
     private func updateWith(cachedHint: Hint) {
+        var hintDescription = cachedHint.description
+
         switch cachedHint.hintType {
         case .nakedSingle:
             if let value = cachedHint.coordinate?.v {
-                let hint = Hint(coordinate: cachedHint.coordinate,
-                                hintType: cachedHint.hintType,
-                                overrideDescription: "Somewhere on the board, there is a naked single \(value). Can you find it?")
-                updateOnSuccess(hint)
-                return
-            } else {
-                break
+                hintDescription = "Somewhere on the board, there is a naked single \(value). Can you find it?"
             }
         case .hiddenSingle:
             if let value = cachedHint.coordinate?.v {
-                let hint = Hint(coordinate: cachedHint.coordinate,
-                                hintType: cachedHint.hintType,
-                                overrideDescription: "Somewhere on the board, there is a hidden single \(value). Can you find it?")
-                updateOnSuccess(hint)
-                return
-            } else {
-                break
+                hintDescription = "Somewhere on the board, there is a hidden single \(value). Can you find it?"
             }
         default:
-            updateOnSuccess(cachedHint)
-            return
+            break
         }
+
+        let hint = Hint(coordinate: cachedHint.coordinate, hintType: cachedHint.hintType, overrideDescription: hintDescription)
+        updateOnSuccess(hint)
     }
 
     private func getHint() async {
@@ -146,20 +147,10 @@ struct HintButton: View {
                 Self.hintCache[cacheKey] = hint
                 updateOnSuccess(hint)
             } else {
-                hintState = .error(nil)
-
-                if isVision {
-                    alertItem = .hintError
-                    alertIsPresented = true
-                }
+                updateOnError(nil)
             }
         } catch {
-            hintState = .error(error as? API.APIError)
-
-            if isVision {
-                alertItem = .hintError
-                alertIsPresented = true
-            }
+            updateOnError(error as? API.APIError)
         }
     }
 }

--- a/Sudoku/Info.plist
+++ b/Sudoku/Info.plist
@@ -15,9 +15,9 @@
 	<key>CFBundlePackageType</key>
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>
-	<string>4.11.0</string>
+	<string>4.12.0</string>
 	<key>CFBundleVersion</key>
-	<string>29</string>
+	<string>30</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSRequiresIPhoneOS</key>

--- a/Sudoku/Models/GridFactory.swift
+++ b/Sudoku/Models/GridFactory.swift
@@ -19,6 +19,7 @@ enum GridFactory {
         case .easy:
             let easyGrids = [easyGrid, easyGrid1, easyGrid2]
             return easyGrids[randomNumber]
+//            return GridFactory.superEasyGrid
         case .medium:
             let mediumGrids = [mediumGrid, mediumGrid1, mediumGrid2]
             return mediumGrids[randomNumber]

--- a/Sudoku/Models/Hint.swift
+++ b/Sudoku/Models/Hint.swift
@@ -1,0 +1,41 @@
+//
+//  Hint.swift
+//  Sudoku
+//
+//  Created by Ray Kim on 2/9/25.
+//  Copyright © 2025 Self. All rights reserved.
+//
+
+import Foundation
+
+struct Hint {
+    enum HintType {
+        case nakedSingle
+        case hiddenSingle
+        case open
+        
+        var rawValue: String {
+            switch self {
+            case .nakedSingle:
+                return "There is at least one naked single on this board. Can you find it?"
+            case .hiddenSingle:
+                return "There is at least one hidden single on this board. Can you find it?"
+            case .open:
+                return "fallback"
+            }
+        }
+    }
+    let coordinate: CoordinateValue?
+    let hintType: HintType
+    private let overrideDescription: String?
+    
+    init(coordinate: CoordinateValue? = nil, hintType: HintType, overrideDescription: String? = nil) {
+        self.coordinate = coordinate
+        self.hintType = hintType
+        self.overrideDescription = overrideDescription
+    }
+    
+    var description: String {
+        return overrideDescription ?? hintType.rawValue
+    }
+}

--- a/Sudoku/SettingsView.swift
+++ b/Sudoku/SettingsView.swift
@@ -21,6 +21,7 @@ struct SettingsView: View {
     private let buildVersion = Bundle.main.infoDictionary?["CFBundleVersion"] as? String ?? ""
 
     @State private var showingDeleteConfirmation = false
+    @State private var showingCacheClearConfirmation = false
 
     var body: some View {
         VStack(spacing: 24) {
@@ -61,6 +62,19 @@ struct SettingsView: View {
                 Button("OK", role: .cancel) { }
             } message: {
                 Text("Data has been deleted successfully.")
+            }
+            Button(action: {
+                HintButton.clearCache()
+                showingCacheClearConfirmation = true
+            }) {
+                Text("Clear hint cache")
+                    .font(Font.system(.headline, design: .rounded))
+                    .foregroundColor(.red)
+            }
+            .alert("Cache cleared", isPresented: $showingCacheClearConfirmation) {
+                Button("OK", role: .cancel) { }
+            } message: {
+                Text("Cache has been cleared successfully.")
             }
             #if os(visionOS)
             HStack(spacing: 0) {

--- a/Sudoku/SudokuSolver.swift
+++ b/Sudoku/SudokuSolver.swift
@@ -106,8 +106,8 @@ struct SudokuSolver {
     /// Finds naked and hidden singles in the grid
     /// - Parameter gridValues: The current state of the Sudoku grid
     /// - Returns: Array of tuples containing coordinate and description of found singles
-    static func findSingles(_ gridValues: [CoordinateValue]) -> [(coordinate: CoordinateValue, description: String)] {
-        var singles: [(CoordinateValue, String)] = []
+    static func findSingles(_ gridValues: [CoordinateValue]) -> [Hint] {
+        var singles = [Hint]()
         let fullGrid = createFullGrid(gridValues)
         let convertedGrid = convertGrid(gridValues)
         
@@ -134,7 +134,8 @@ struct SudokuSolver {
                 if possibleValues.count == 1 {
                     if let value = possibleValues.first {
                         let nakedSingle = CoordinateValue(r: row, c: col, s: squareIndex, v: value)
-                        singles.append((nakedSingle, "There is at least one naked single on this board. Can you find it?"))
+                        let hint = Hint(coordinate: nakedSingle, hintType: .nakedSingle)
+                        singles.append(hint)
                     }
                 }
                 
@@ -157,8 +158,9 @@ struct SudokuSolver {
                         
                         if isHiddenInRow || isHiddenInCol || isHiddenInSquare {
                             let hiddenSingle = CoordinateValue(r: row, c: col, s: squareIndex, v: value)
-                            let location = isHiddenInRow ? "row" : (isHiddenInCol ? "column" : "square")
-                            singles.append((hiddenSingle, "There is a hidden single on this board. Can you find it?"))
+//                            let location = isHiddenInRow ? "row" : (isHiddenInCol ? "column" : "square")
+                            let hint = Hint(coordinate: hiddenSingle, hintType: .hiddenSingle)
+                            singles.append(hint)
                         }
                     }
                 }

--- a/Sudoku/SudokuSolver.swift
+++ b/Sudoku/SudokuSolver.swift
@@ -89,4 +89,82 @@ struct SudokuSolver {
             return colIndex
         }
     }
+
+    /// Creates a full 9x9 grid with empty cells marked as nil
+    static func createFullGrid(_ partialGrid: [CoordinateValue]) -> [[CoordinateValue?]] {
+        var fullGrid = Array(repeating: Array(repeating: nil as CoordinateValue?, count: 9), count: 9)
+        let convertedGrid = convertGrid(partialGrid)
+        
+        // Fill in the known values
+        for value in convertedGrid {
+            fullGrid[value.r][value.c] = value
+        }
+        
+        return fullGrid
+    }
+
+    /// Finds naked and hidden singles in the grid
+    /// - Parameter gridValues: The current state of the Sudoku grid
+    /// - Returns: Array of tuples containing coordinate and description of found singles
+    static func findSingles(_ gridValues: [CoordinateValue]) -> [(coordinate: CoordinateValue, description: String)] {
+        var singles: [(CoordinateValue, String)] = []
+        let fullGrid = createFullGrid(gridValues)
+        let convertedGrid = convertGrid(gridValues)
+        
+        // Check each cell in the grid
+        for row in 0..<9 {
+            for col in 0..<9 {
+                // Skip filled cells
+                if fullGrid[row][col] != nil { continue }
+                
+                // Calculate square index
+                let squareIndex = (row / 3) * 3 + (col / 3)
+                
+                // Get all values in the same row, column, and square
+                let rowValues = convertedGrid.filter { $0.r == row }.map { $0.v }
+                let colValues = convertedGrid.filter { $0.c == col }.map { $0.v }
+                let squareValues = convertedGrid.filter { $0.s == squareIndex }.map { $0.v }
+                
+                // Find possible values for this cell
+                let allPossible = Set(1...9)
+                let usedValues = Set(rowValues + colValues + squareValues)
+                let possibleValues = allPossible.subtracting(usedValues)
+                
+                // Check for naked single (only one possible value)
+                if possibleValues.count == 1 {
+                    if let value = possibleValues.first {
+                        let nakedSingle = CoordinateValue(r: row, c: col, s: squareIndex, v: value)
+                        singles.append((nakedSingle, "There is at least one naked single on this board. Can you find it?"))
+                    }
+                }
+                
+                // Check for hidden single in row, column, and square
+                for value in 1...9 {
+                    if !usedValues.contains(value) {
+                        let emptyCellsInRow = (0..<9).filter { fullGrid[row][$0] == nil }.count
+                        let emptyCellsInCol = (0..<9).filter { fullGrid[$0][col] == nil }.count
+                        let squareStartRow = (row / 3) * 3
+                        let squareStartCol = (col / 3) * 3
+                        let emptyCellsInSquare = (squareStartRow..<squareStartRow+3).flatMap { r in
+                            (squareStartCol..<squareStartCol+3).map { c in
+                                fullGrid[r][c] == nil
+                            }
+                        }.filter { $0 }.count
+                        
+                        let isHiddenInRow = emptyCellsInRow == 1
+                        let isHiddenInCol = emptyCellsInCol == 1
+                        let isHiddenInSquare = emptyCellsInSquare == 1
+                        
+                        if isHiddenInRow || isHiddenInCol || isHiddenInSquare {
+                            let hiddenSingle = CoordinateValue(r: row, c: col, s: squareIndex, v: value)
+                            let location = isHiddenInRow ? "row" : (isHiddenInCol ? "column" : "square")
+                            singles.append((hiddenSingle, "There is a hidden single on this board. Can you find it?"))
+                        }
+                    }
+                }
+            }
+        }
+        
+        return singles
+    }
 }


### PR DESCRIPTION
### Improvements to hint functionality:

* [`Sudoku/API.swift`](diffhunk://#diff-98a2c5c25fa4da04a4501057f46e1f7e831247170e88578259f869bd688058fdL34-R70): Modified the `getHint` function to return a `Hint` object instead of a string, and updated the hint generation logic to include single hint detection before making an API call.
* [`Sudoku/SudokuSolver.swift`](diffhunk://#diff-6183ac8707eb1c9513fd9c16b9d179dd21ea08b36f39af1f7b58dcfe74878be3R92-R171): Added new functions `createFullGrid` and `findSingles` to identify naked and hidden singles in the Sudoku grid.

### Caching mechanism:

* [`Sudoku/Game/HintButton.swift`](diffhunk://#diff-92ab43f104983fbc7123042aa871bc34d6e3948ec72e8d7f8aed7f3e535f7ca7R40-R44): Introduced a static cache for hints and methods to clear the cache and retrieve hints from the cache. [[1]](diffhunk://#diff-92ab43f104983fbc7123042aa871bc34d6e3948ec72e8d7f8aed7f3e535f7ca7R40-R44) [[2]](diffhunk://#diff-92ab43f104983fbc7123042aa871bc34d6e3948ec72e8d7f8aed7f3e535f7ca7L94-R153)
* [`Sudoku/SettingsView.swift`](diffhunk://#diff-44c412214dc79434af96754e37fabc68fa3479d781a50b402252768c22949b0fR24): Added a button to clear the hint cache in the settings view. [[1]](diffhunk://#diff-44c412214dc79434af96754e37fabc68fa3479d781a50b402252768c22949b0fR24) [[2]](diffhunk://#diff-44c412214dc79434af96754e37fabc68fa3479d781a50b402252768c22949b0fR66-R78)

### New `Hint` model:

* [`Sudoku/Models/Hint.swift`](diffhunk://#diff-4b94404143c7a4c9dc99409a06ff2e529b0f3753b4b4475cb2e60983c7046089R1-R41): Created a new `Hint` struct to encapsulate hint details, including the coordinate, hint type, and description.

### Minor updates:

* [`Sudoku.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved`](diffhunk://#diff-616d76c374b39e6d2ee04b202a1b5ce58471d5b35277804c29543072e043aba1L10-R10): Updated the package revision for `aiproxyswift`.
* [`Sudoku/Models/GridFactory.swift`](diffhunk://#diff-b2c9efd52b7f554539ad452ecd62415ab0a80564c60d2bfdc3e7e478320f91d4R22): Commented out an unused return statement for the super easy grid.

Note: this was generated with Copilot